### PR TITLE
Add tests for getDefaultConfigPath

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.activate = activate;
 exports.deactivate = deactivate;
+exports.getDefaultConfigPath = getDefaultConfigPath;
 const vscode = require("vscode");
 const cp = require("child_process");
 const os = require("os");

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "package": "npx @vscode/vsce package",
     "package-rename": "npx @vscode/vsce package && node -e \"const fs = require('fs'); const pkg = require('./package.json'); try { fs.renameSync('claude-restarter-' + pkg.version + '.vsix', 'claude-restarter.vsix'); console.log('Renamed VSIX file successfully'); } catch(e) { console.error('Error renaming file:', e.message); }\"",
     "publish": "npx @vscode/vsce publish",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./test/getDefaultConfigPath.test.js"
   },
   "keywords": [
     "claude",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,17 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+
+export function getDefaultConfigPath(): string {
+    const platform = os.platform();
+    if (platform === 'darwin') {
+        return path.join(os.homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+    } else if (platform === 'win32') {
+        return path.join(os.homedir(), 'AppData', 'Roaming', 'Claude', 'claude_desktop_config.json');
+    }
+    return path.join(os.homedir(), '.config', 'Claude', 'claude_desktop_config.json');
+}
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Claude Restarter extension is now active');

--- a/test/getDefaultConfigPath.test.js
+++ b/test/getDefaultConfigPath.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const Module = require('module');
+
+// Stub the 'vscode' module required by extension.js
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'vscode') return {};
+  return originalLoad(request, parent, isMain);
+};
+
+const { getDefaultConfigPath } = require('../extension');
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`\u2714 ${name}`);
+  } catch (err) {
+    console.error(`\u2716 ${name}`);
+    console.error(err);
+    process.exitCode = 1;
+  }
+}
+
+function stubOs(platform, homeDir) {
+  const originalPlatform = os.platform;
+  const originalHomedir = os.homedir;
+  os.platform = () => platform;
+  os.homedir = () => homeDir;
+  return () => {
+    os.platform = originalPlatform;
+    os.homedir = originalHomedir;
+  };
+}
+
+runTest('returns macOS path on darwin', () => {
+  const restore = stubOs('darwin', '/Users/test');
+  const expected = path.join('/Users/test', 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  assert.strictEqual(getDefaultConfigPath(), expected);
+  restore();
+});
+
+runTest('returns Windows path on win32', () => {
+  const restore = stubOs('win32', 'C:\\Users\\test');
+  const expected = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'Claude', 'claude_desktop_config.json');
+  assert.strictEqual(getDefaultConfigPath(), expected);
+  restore();
+});
+
+runTest('returns Linux path on linux', () => {
+  const restore = stubOs('linux', '/home/test');
+  const expected = path.join('/home/test', '.config', 'Claude', 'claude_desktop_config.json');
+  assert.strictEqual(getDefaultConfigPath(), expected);
+  restore();
+});


### PR DESCRIPTION
## Summary
- expose `getDefaultConfigPath` from extension files
- add unit tests verifying the default config path logic
- update the `test` script to run the new tests

## Testing
- `npm test`