### PR TITLE
Update file watcher on config change

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -67,7 +67,7 @@ function activate(context) {
     // Get the config file path from settings
     const config = vscode.workspace.getConfiguration('claudeRestarter');
     const defaultPath = getDefaultConfigPath();
-    const configFilePath = config.get('configFilePath', defaultPath);
+    let configFilePath = config.get('configFilePath', defaultPath);
     
     // Log the path we're watching
     console.log(`Claude Restarter is watching for changes to: ${configFilePath}`);
@@ -84,7 +84,7 @@ function activate(context) {
     });
     
     // Create file watcher - use glob pattern for specific file
-    const fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath, false, false, false);
+    let fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath, false, false, false);
     
     // When the file is created (useful if it doesn't exist yet)
     fileWatcher.onDidCreate((uri) => {
@@ -124,7 +124,7 @@ function activate(context) {
             // Update the file watcher with the new path
             console.log('Configuration changed, updating file watcher...');
             fileWatcher.dispose();
-            
+
             const newConfigPath = vscode.workspace.getConfiguration('claudeRestarter').get('configFilePath', defaultPath);
             console.log(`New config path: ${newConfigPath}`);
             
@@ -151,6 +151,8 @@ function activate(context) {
                 });
                 
                 context.subscriptions.push(newFileWatcher);
+                fileWatcher = newFileWatcher;
+                configFilePath = newConfigPath;
                 vscode.window.showInformationMessage(`Now watching: ${newConfigPath}`);
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,10 +13,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Get the config file path from settings
     const config = vscode.workspace.getConfiguration('claudeRestarter');
-    const configFilePath = config.get<string>('configFilePath', '/Users/nick/Library/Application Support/Claude/claude_desktop_config.json');
+    let configFilePath = config.get<string>('configFilePath', '/Users/nick/Library/Application Support/Claude/claude_desktop_config.json');
     
     // File watcher for the config file
-    const fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath);
+    let fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath);
     
     // When the file is saved, restart Claude
     fileWatcher.onDidChange(() => {
@@ -37,6 +37,8 @@ export function activate(context: vscode.ExtensionContext) {
                     restartClaude();
                 });
                 context.subscriptions.push(newFileWatcher);
+                fileWatcher = newFileWatcher;
+                configFilePath = newConfigPath;
             }
         }
     });


### PR DESCRIPTION
## Summary
- allow config path watcher to be reassigned
- update TypeScript sources accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*