### PR TITLE
Fix watcher update when config path changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,10 +13,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Get the config file path from settings
     const config = vscode.workspace.getConfiguration('claudeRestarter');
-    const configFilePath = config.get<string>('configFilePath', '/Users/nick/Library/Application Support/Claude/claude_desktop_config.json');
+    let configFilePath = config.get<string>('configFilePath', '/Users/nick/Library/Application Support/Claude/claude_desktop_config.json');
     
     // File watcher for the config file
-    const fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath);
+    let fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath);
     
     // When the file is saved, restart Claude
     fileWatcher.onDidChange(() => {
@@ -29,14 +29,14 @@ export function activate(context: vscode.ExtensionContext) {
         if (e.affectsConfiguration('claudeRestarter.configFilePath')) {
             // Update the file watcher with the new path
             fileWatcher.dispose();
-            const newConfigPath = vscode.workspace.getConfiguration('claudeRestarter').get<string>('configFilePath', '');
-            if (newConfigPath) {
-                const newFileWatcher = vscode.workspace.createFileSystemWatcher(newConfigPath);
-                newFileWatcher.onDidChange(() => {
+            configFilePath = vscode.workspace.getConfiguration('claudeRestarter').get<string>('configFilePath', '');
+            if (configFilePath) {
+                fileWatcher = vscode.workspace.createFileSystemWatcher(configFilePath);
+                fileWatcher.onDidChange(() => {
                     vscode.window.showInformationMessage('Claude config file saved, restarting Claude...');
                     restartClaude();
                 });
-                context.subscriptions.push(newFileWatcher);
+                context.subscriptions.push(fileWatcher);
             }
         }
     });


### PR DESCRIPTION
## Summary
- properly update configFilePath and watcher when settings change
- keep TypeScript source in sync

## Testing
- `npm test` *(fails: Error: no test specified)*